### PR TITLE
Remove runtime dependency on bs-jest

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -12,7 +12,7 @@
       "type": "dev"
     }
   ],
-  "bs-dependencies": [
+  "bs-dev-dependencies": [
     "bs-jest"
   ],
   "namespace": true,

--- a/package.json
+++ b/package.json
@@ -23,9 +23,8 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "bs-platform": "2.0.0"
-  },
-  "dependencies": {
+    "bs-platform": "2.0.0",
     "bs-jest": "^0.2.0"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
Jest isn't required at runtime and probably should not be included as a standard dependency.