### PR TITLE
aperature -> aperture + refmt 3.3.3 for the tests

### DIFF
--- a/__tests__/Dict_test.re
+++ b/__tests__/Dict_test.re
@@ -6,106 +6,127 @@ open Dict;
 
 let dict: t(int) = [("a", 1), ("b", 2), ("c", 3)];
 
-test("get", () => expect((get("b", dict), get("d", dict))) |> toEqual((Some(2), None)));
-
-describe(
-  "set",
-  () => {
-    test("existing key", () => expect(set("b", 5, dict) |> get("b")) |> toEqual(Some(5)));
-    test("nonexistant key", () => expect(set("d", 5, dict) |> get("d")) |> toEqual(Some(5)))
-  }
+test("get", () =>
+  expect((get("b", dict), get("d", dict))) |> toEqual((Some(2), None))
 );
 
-test(
-  "eqProps",
-  () =>
-    expect((eqProps("a", dict, [("a", 1)]), eqProps("a", dict, [("a", 2)])))
-    |> toEqual((true, false))
+describe("set", () => {
+  test("existing key", () =>
+    expect(set("b", 5, dict) |> get("b")) |> toEqual(Some(5))
+  );
+  test("nonexistant key", () =>
+    expect(set("d", 5, dict) |> get("d")) |> toEqual(Some(5))
+  );
+});
+
+test("eqProps", () =>
+  expect((
+    eqProps("a", dict, [("a", 1)]),
+    eqProps("a", dict, [("a", 2)]),
+  ))
+  |> toEqual((true, false))
 );
 
-test("map", () => expect(map((x) => x * 2, dict)) |> toEqual([("a", 2), ("b", 4), ("c", 6)]));
-
-test(
-  "mapi",
-  () => expect(mapi((k, _) => k, dict)) |> toEqual([("a", "a"), ("b", "b"), ("c", "c")])
+test("map", () =>
+  expect(map(x => x * 2, dict))
+  |> toEqual([("a", 2), ("b", 4), ("c", 6)])
 );
 
-test(
-  "evolve",
-  () => {
-    let e = [("a", Function.identity), ("b", (x) => x * 2)];
-    expect(evolve(e, dict)) |> toEqual([("a", 1), ("b", 4), ("c", 3)])
-  }
+test("mapi", () =>
+  expect(mapi((k, _) => k, dict))
+  |> toEqual([("a", "a"), ("b", "b"), ("c", "c")])
 );
 
-test("has", () => expect((has("a", dict), has("d", dict))) |> toEqual((true, false)));
+test("evolve", () => {
+  let e = [("a", Function.identity), ("b", x => x * 2)];
+  expect(evolve(e, dict)) |> toEqual([("a", 1), ("b", 4), ("c", 3)]);
+});
 
-test(
-  "invert",
-  () => {
-    let raceResultsByFirstName = [("first", "alice"), ("second", "jake"), ("third", "alice")];
-    expect(invert(raceResultsByFirstName))
-    |> toEqual([("alice", ["first", "third"]), ("jake", ["second"])])
-  }
+test("has", () =>
+  expect((has("a", dict), has("d", dict))) |> toEqual((true, false))
 );
 
-test("keys", () => expect(keys(dict)) |> toEqual(["a", "b", "c"]));
+test("invert", () => {
+  let raceResultsByFirstName = [
+    ("first", "alice"),
+    ("second", "jake"),
+    ("third", "alice"),
+  ];
+  expect(invert(raceResultsByFirstName))
+  |> toEqual([("alice", ["first", "third"]), ("jake", ["second"])]);
+});
 
-test("merge", () => expect(merge(dict, [("a", 2)])) |> toEqual([("a", 2), ("b", 2), ("c", 3)]));
-
-test(
-  "mergeWithKey",
-  () =>
-    expect(mergeWithKey((k, l, r) => k == "a" ? [l, r] : [r], dict, [("a", 2), ("b", 5)]))
-    |> toEqual([("a", [1, 2]), ("b", [5])])
+test("keys", () =>
+  expect(keys(dict)) |> toEqual(["a", "b", "c"])
 );
 
-test(
-  "mergeWith",
-  () =>
-    expect(mergeWith((l, r) => [l, r], dict, [("a", 2), ("b", 3)]))
-    |> toEqual([("a", [1, 2]), ("b", [2, 3])])
+test("merge", () =>
+  expect(merge(dict, [("a", 2)]))
+  |> toEqual([("a", 2), ("b", 2), ("c", 3)])
 );
 
-test("omit", () => expect(omit(["a", "c"], dict)) |> toEqual([("b", 2)]));
+test("mergeWithKey", () =>
+  expect(
+    mergeWithKey(
+      (k, l, r) => k == "a" ? [l, r] : [r],
+      dict,
+      [("a", 2), ("b", 5)],
+    ),
+  )
+  |> toEqual([("a", [1, 2]), ("b", [5])])
+);
 
-test("pick", () => expect(pick(["a", "c"], dict)) |> toEqual([("a", 1), ("c", 3)]));
+test("mergeWith", () =>
+  expect(mergeWith((l, r) => [l, r], dict, [("a", 2), ("b", 3)]))
+  |> toEqual([("a", [1, 2]), ("b", [2, 3])])
+);
+
+test("omit", () =>
+  expect(omit(["a", "c"], dict)) |> toEqual([("b", 2)])
+);
+
+test("pick", () =>
+  expect(pick(["a", "c"], dict)) |> toEqual([("a", 1), ("c", 3)])
+);
 
 /* TODO: project */
-test("values", () => expect(values(dict)) |> toEqual([1, 2, 3]));
-
-test(
-  "where",
-  () => {
-    let w0 = [("a", Util.eq(1)), ("c", (x) => x < 4)];
-    let w1 = [("b", (x) => x mod 2 == 1)];
-    expect((where(w0, dict), where(w1, dict))) |> toEqual((true, false))
-  }
+test("values", () =>
+  expect(values(dict)) |> toEqual([1, 2, 3])
 );
 
-test(
-  "where",
-  () => {
-    let w0 = [("a", 1), ("c", 3)];
-    let w1 = [("b", 4)];
-    expect((whereEq(w0, dict), whereEq(w1, dict))) |> toEqual((true, false))
-  }
+test("where", () => {
+  let w0 = [("a", Util.eq(1)), ("c", x => x < 4)];
+  let w1 = [("b", x => x mod 2 == 1)];
+  expect((where(w0, dict), where(w1, dict))) |> toEqual((true, false));
+});
+
+test("where", () => {
+  let w0 = [("a", 1), ("c", 3)];
+  let w1 = [("b", 4)];
+  expect((whereEq(w0, dict), whereEq(w1, dict))) |> toEqual((true, false));
+});
+
+test("filter", () =>
+  expect(filter(v => v > 1, dict)) |> toEqual([("b", 2), ("c", 3)])
 );
 
-test("filter", () => expect(filter((v) => v > 1, dict)) |> toEqual([("b", 2), ("c", 3)]));
-
-test("filteri", () => expect(filteri((k, _) => k == "a", dict)) |> toEqual([("a", 1)]));
-
-test("fold_left", () => expect(
-    fold_left((acc, _, v) => acc + v, 0, dict)
-  ) |> toEqual(6)
+test("filteri", () =>
+  expect(filteri((k, _) => k == "a", dict)) |> toEqual([("a", 1)])
 );
 
-test("fold_right", () => expect(
-    fold_right((_, v, acc) => acc +   (v > 1 ? v : 0), dict, 0)
-  ) |> toEqual(5)
+test("fold_left", () =>
+  expect(fold_left((acc, _, v) => acc + v, 0, dict)) |> toEqual(6)
 );
 
-test("unzip", () => expect(unzip(dict)) |> toEqual((["a", "b", "c"], [1, 2, 3])))
+test("fold_right", () =>
+  expect(fold_right((_, v, acc) => acc + (v > 1 ? v : 0), dict, 0))
+  |> toEqual(5)
+);
 
-test("unzip", () => expect(unzip([])) |> toEqual(([], [])))
+test("unzip", () =>
+  expect(unzip(dict)) |> toEqual((["a", "b", "c"], [1, 2, 3]))
+);
+
+test("unzip", () =>
+  expect(unzip([])) |> toEqual(([], []))
+);

--- a/__tests__/Lens_test.re
+++ b/__tests__/Lens_test.re
@@ -7,7 +7,7 @@ open Lens;
 type nestType = {
   innerBasic: int,
   innerSome: option(int),
-  innerNone: option(int)
+  innerNone: option(int),
 };
 
 type recordType = {
@@ -20,12 +20,16 @@ type recordType = {
   list: list(int),
   emptyList: list(int),
   dict: Dict.t(int),
-  tuple: (int, int)
+  tuple: (int, int),
 };
 
 let record = {
   basic: 1,
-  nest: {innerBasic: 2, innerSome: Some(3), innerNone: None},
+  nest: {
+    innerBasic: 2,
+    innerSome: Some(3),
+    innerNone: None,
+  },
   some: Some(4),
   none: None,
   someNest: Some({innerBasic: 5, innerSome: Some(6), innerNone: None}),
@@ -33,240 +37,235 @@ let record = {
   list: [1, 2, 3],
   emptyList: [],
   dict: [("a", 7)],
-  tuple: (8, 9)
+  tuple: (8, 9),
 };
 
-let basicLens = make((a) => a.basic, (v, a) => {...a, basic: v});
+let basicLens = make(a => a.basic, (v, a) => {...a, basic: v});
 
-let innerBasicLens = make((a) => a.innerBasic, (v, a) => {...a, innerBasic: v});
+let innerBasicLens =
+  make(a => a.innerBasic, (v, a) => {...a, innerBasic: v});
 
-let nestLens = make((a) => a.nest, (v, a) => {...a, nest: v});
+let nestLens = make(a => a.nest, (v, a) => {...a, nest: v});
 
-let someLens = make((a) => a.some, (v, a) => {...a, some: v}) >>- optional(0);
+let someLens =
+  make(a => a.some, (v, a) => {...a, some: v}) >>- optional(0);
 
-let noneLens = make((a) => a.none, (v, a) => {...a, none: v}) >>- optional(0);
+let noneLens =
+  make(a => a.none, (v, a) => {...a, none: v}) >>- optional(0);
 
 let someNestLens =
-  make((a) => a.someNest, (v, a) => {...a, someNest: v})
+  make(a => a.someNest, (v, a) => {...a, someNest: v})
   >>- optional({innerBasic: 0, innerSome: Some(0), innerNone: None});
 
 let noneNestLens =
-  make((a) => a.noneNest, (v, a) => {...a, someNest: v})
+  make(a => a.noneNest, (v, a) => {...a, someNest: v})
   >>- optional({innerBasic: 0, innerSome: Some(0), innerNone: None});
 
-let listLens = make((a) => a.list, (v, a) => {...a, list: v});
+let listLens = make(a => a.list, (v, a) => {...a, list: v});
 
-let emptyListLens = make((a) => a.emptyList, (v, a) => {...a, emptyList: v});
+let emptyListLens = make(a => a.emptyList, (v, a) => {...a, emptyList: v});
 
-let dictLens = make((a) => a.dict, (v, a) => {...a, dict: v});
+let dictLens = make(a => a.dict, (v, a) => {...a, dict: v});
 
 let aLens = prop("a") >>- optional(0);
 
-let tupleLens = make((a) => a.tuple, (v, a) => {...a, tuple: v});
+let tupleLens = make(a => a.tuple, (v, a) => {...a, tuple: v});
 
-describe(
-  "view",
-  () => {
-    test("basic", () => expect(view(basicLens, record)) |> toEqual(1));
-    test("nest", () => expect(view(nestLens >>- innerBasicLens, record)) |> toEqual(2));
-    test("some", () => expect(view(someLens, record)) |> toEqual(4));
-    test("none", () => expect(view(noneLens, record)) |> toEqual(0));
-    test("someNest", () => expect(view(someNestLens >>- innerBasicLens, record)) |> toEqual(5));
-    test("noneNest", () => expect(view(noneNestLens >>- innerBasicLens, record)) |> toEqual(0));
-    describe(
-      "list",
-      () => {
-        test("head", () => expect(view(listLens >>- head >>- optional(0), record)) |> toEqual(1));
-        test(
-          "tail",
-          () => expect(view(listLens >>- tail >>- optional([0]), record)) |> toEqual([2, 3])
-        );
-        test(
-          "index",
-          () => expect(view(listLens >>- index(1) >>- optional(0), record)) |> toEqual(2)
-        )
-      }
+describe("view", () => {
+  test("basic", () =>
+    expect(view(basicLens, record)) |> toEqual(1)
+  );
+  test("nest", () =>
+    expect(view(nestLens >>- innerBasicLens, record)) |> toEqual(2)
+  );
+  test("some", () =>
+    expect(view(someLens, record)) |> toEqual(4)
+  );
+  test("none", () =>
+    expect(view(noneLens, record)) |> toEqual(0)
+  );
+  test("someNest", () =>
+    expect(view(someNestLens >>- innerBasicLens, record)) |> toEqual(5)
+  );
+  test("noneNest", () =>
+    expect(view(noneNestLens >>- innerBasicLens, record)) |> toEqual(0)
+  );
+  describe("list", () => {
+    test("head", () =>
+      expect(view(listLens >>- head >>- optional(0), record)) |> toEqual(1)
     );
-    test("dict", () => expect(view(dictLens >>- aLens, record)) |> toEqual(7));
-    describe(
-      "tuple",
-      () => {
-        test("first", () => expect(view(tupleLens >>- first, record)) |> toEqual(8));
-        test("second", () => expect(view(tupleLens >>- second, record)) |> toEqual(9))
-      }
-    )
-  }
-);
+    test("tail", () =>
+      expect(view(listLens >>- tail >>- optional([0]), record))
+      |> toEqual([2, 3])
+    );
+    test("index", () =>
+      expect(view(listLens >>- index(1) >>- optional(0), record))
+      |> toEqual(2)
+    );
+  });
+  test("dict", () =>
+    expect(view(dictLens >>- aLens, record)) |> toEqual(7)
+  );
+  describe("tuple", () => {
+    test("first", () =>
+      expect(view(tupleLens >>- first, record)) |> toEqual(8)
+    );
+    test("second", () =>
+      expect(view(tupleLens >>- second, record)) |> toEqual(9)
+    );
+  });
+});
 
-describe(
-  "set",
-  () => {
-    test("basic", () => expect(set(basicLens, 5, record) |> view(basicLens)) |> toEqual(5));
-    test(
-      "nest",
-      () =>
-        expect(set(nestLens >>- innerBasicLens, 5, record) |> view(nestLens >>- innerBasicLens))
-        |> toEqual(5)
-    );
-    test("some", () => expect(set(someLens, 5, record) |> view(someLens)) |> toEqual(5));
-    test("none", () => expect(set(noneLens, 5, record) |> view(noneLens)) |> toEqual(5));
-    test(
-      "someNest",
-      () =>
-        expect(
-          set(someNestLens >>- innerBasicLens, 7, record) |> view(someNestLens >>- innerBasicLens)
-        )
-        |> toEqual(7)
-    );
-    test(
-      "noneNest",
-      () =>
-        expect(
-          set(noneNestLens >>- innerBasicLens, 5, record) |> view(noneNestLens >>- innerBasicLens)
-        )
-        |> toEqual(0)
-    );
-    describe(
-      "list",
-      () => {
-        test(
-          "head",
-          () =>
-            expect(
-              set(listLens >>- head >>- optional(0), 5, record)
-              |> view(listLens >>- head >>- optional(0))
-            )
-            |> toEqual(5)
-        );
-        test(
-          "tail",
-          () =>
-            expect(
-              set(listLens >>- tail >>- optional([0]), [5, 5], record)
-              |> view(listLens >>- tail >>- optional([0]))
-            )
-            |> toEqual([5, 5])
-        );
-        test(
-          "index",
-          () =>
-            expect(
-              set(listLens >>- index(1) >>- optional(0), 5, record)
-              |> view(listLens >>- index(1) >>- optional(0))
-            )
-            |> toEqual(5)
-        )
-      }
-    );
-    test(
-      "dict",
-      () => expect(set(dictLens >>- aLens, 5, record) |> view(dictLens >>- aLens)) |> toEqual(5)
-    );
-    describe(
-      "tuple",
-      () => {
-        test(
-          "first",
-          () =>
-            expect(set(tupleLens >>- first, 5, record) |> view(tupleLens >>- first)) |> toEqual(5)
-        );
-        test(
-          "second",
-          () =>
-            expect(set(tupleLens >>- second, 5, record) |> view(tupleLens >>- second))
-            |> toEqual(5)
-        )
-      }
+describe("set", () => {
+  test("basic", () =>
+    expect(set(basicLens, 5, record) |> view(basicLens)) |> toEqual(5)
+  );
+  test("nest", () =>
+    expect(
+      set(nestLens >>- innerBasicLens, 5, record)
+      |> view(nestLens >>- innerBasicLens),
     )
-  }
-);
+    |> toEqual(5)
+  );
+  test("some", () =>
+    expect(set(someLens, 5, record) |> view(someLens)) |> toEqual(5)
+  );
+  test("none", () =>
+    expect(set(noneLens, 5, record) |> view(noneLens)) |> toEqual(5)
+  );
+  test("someNest", () =>
+    expect(
+      set(someNestLens >>- innerBasicLens, 7, record)
+      |> view(someNestLens >>- innerBasicLens),
+    )
+    |> toEqual(7)
+  );
+  test("noneNest", () =>
+    expect(
+      set(noneNestLens >>- innerBasicLens, 5, record)
+      |> view(noneNestLens >>- innerBasicLens),
+    )
+    |> toEqual(0)
+  );
+  describe("list", () => {
+    test("head", () =>
+      expect(
+        set(listLens >>- head >>- optional(0), 5, record)
+        |> view(listLens >>- head >>- optional(0)),
+      )
+      |> toEqual(5)
+    );
+    test("tail", () =>
+      expect(
+        set(listLens >>- tail >>- optional([0]), [5, 5], record)
+        |> view(listLens >>- tail >>- optional([0])),
+      )
+      |> toEqual([5, 5])
+    );
+    test("index", () =>
+      expect(
+        set(listLens >>- index(1) >>- optional(0), 5, record)
+        |> view(listLens >>- index(1) >>- optional(0)),
+      )
+      |> toEqual(5)
+    );
+  });
+  test("dict", () =>
+    expect(set(dictLens >>- aLens, 5, record) |> view(dictLens >>- aLens))
+    |> toEqual(5)
+  );
+  describe("tuple", () => {
+    test("first", () =>
+      expect(
+        set(tupleLens >>- first, 5, record) |> view(tupleLens >>- first),
+      )
+      |> toEqual(5)
+    );
+    test("second", () =>
+      expect(
+        set(tupleLens >>- second, 5, record) |> view(tupleLens >>- second),
+      )
+      |> toEqual(5)
+    );
+  });
+});
 
-describe(
-  "over",
-  () => {
-    let double = (x) => x * 2;
-    test("basic", () => expect(over(basicLens, double, record) |> view(basicLens)) |> toEqual(2));
-    test(
-      "nest",
-      () =>
-        expect(
-          over(nestLens >>- innerBasicLens, double, record) |> view(nestLens >>- innerBasicLens)
-        )
-        |> toEqual(4)
-    );
-    test("some", () => expect(over(someLens, double, record) |> view(someLens)) |> toEqual(8));
-    test("none", () => expect(over(noneLens, double, record) |> view(noneLens)) |> toEqual(0));
-    test(
-      "someNest",
-      () =>
-        expect(
-          over(someNestLens >>- innerBasicLens, double, record)
-          |> view(someNestLens >>- innerBasicLens)
-        )
-        |> toEqual(10)
-    );
-    test(
-      "noneNest",
-      () =>
-        expect(
-          over(noneNestLens >>- innerBasicLens, double, record)
-          |> view(noneNestLens >>- innerBasicLens)
-        )
-        |> toEqual(0)
-    );
-    describe(
-      "list",
-      () => {
-        test(
-          "head",
-          () =>
-            expect(
-              over(listLens >>- head >>- optional(0), double, record)
-              |> view(listLens >>- head >>- optional(0))
-            )
-            |> toEqual(2)
-        );
-        test(
-          "tail",
-          () =>
-            expect(
-              over(listLens >>- tail >>- optional([0]), List.map(double), record)
-              |> view(listLens >>- tail >>- optional([0]))
-            )
-            |> toEqual([4, 6])
-        );
-        test(
-          "index",
-          () =>
-            expect(
-              over(listLens >>- index(1) >>- optional(0), double, record)
-              |> view(listLens >>- index(1) >>- optional(0))
-            )
-            |> toEqual(4)
-        )
-      }
-    );
-    test(
-      "dict",
-      () =>
-        expect(over(dictLens >>- aLens, double, record) |> view(dictLens >>- aLens)) |> toEqual(14)
-    );
-    describe(
-      "tuple",
-      () => {
-        test(
-          "first",
-          () =>
-            expect(over(tupleLens >>- first, double, record) |> view(tupleLens >>- first))
-            |> toEqual(16)
-        );
-        test(
-          "second",
-          () =>
-            expect(over(tupleLens >>- second, double, record) |> view(tupleLens >>- second))
-            |> toEqual(18)
-        )
-      }
+describe("over", () => {
+  let double = x => x * 2;
+  test("basic", () =>
+    expect(over(basicLens, double, record) |> view(basicLens))
+    |> toEqual(2)
+  );
+  test("nest", () =>
+    expect(
+      over(nestLens >>- innerBasicLens, double, record)
+      |> view(nestLens >>- innerBasicLens),
     )
-  }
-);
+    |> toEqual(4)
+  );
+  test("some", () =>
+    expect(over(someLens, double, record) |> view(someLens)) |> toEqual(8)
+  );
+  test("none", () =>
+    expect(over(noneLens, double, record) |> view(noneLens)) |> toEqual(0)
+  );
+  test("someNest", () =>
+    expect(
+      over(someNestLens >>- innerBasicLens, double, record)
+      |> view(someNestLens >>- innerBasicLens),
+    )
+    |> toEqual(10)
+  );
+  test("noneNest", () =>
+    expect(
+      over(noneNestLens >>- innerBasicLens, double, record)
+      |> view(noneNestLens >>- innerBasicLens),
+    )
+    |> toEqual(0)
+  );
+  describe("list", () => {
+    test("head", () =>
+      expect(
+        over(listLens >>- head >>- optional(0), double, record)
+        |> view(listLens >>- head >>- optional(0)),
+      )
+      |> toEqual(2)
+    );
+    test("tail", () =>
+      expect(
+        over(listLens >>- tail >>- optional([0]), List.map(double), record)
+        |> view(listLens >>- tail >>- optional([0])),
+      )
+      |> toEqual([4, 6])
+    );
+    test("index", () =>
+      expect(
+        over(listLens >>- index(1) >>- optional(0), double, record)
+        |> view(listLens >>- index(1) >>- optional(0)),
+      )
+      |> toEqual(4)
+    );
+  });
+  test("dict", () =>
+    expect(
+      over(dictLens >>- aLens, double, record) |> view(dictLens >>- aLens),
+    )
+    |> toEqual(14)
+  );
+  describe("tuple", () => {
+    test("first", () =>
+      expect(
+        over(tupleLens >>- first, double, record)
+        |> view(tupleLens >>- first),
+      )
+      |> toEqual(16)
+    );
+    test("second", () =>
+      expect(
+        over(tupleLens >>- second, double, record)
+        |> view(tupleLens >>- second),
+      )
+      |> toEqual(18)
+    );
+  });
+});

--- a/__tests__/Option_test.re
+++ b/__tests__/Option_test.re
@@ -4,86 +4,77 @@ open Expect;
 
 open Option;
 
-test(
-  "some",
-  () =>
-    switch (some(1)) {
-    | Some(a) => expect(a) |> toEqual(1)
-    | _ => expect(0) |> toEqual(1)
-    }
+test("some", () =>
+  switch (some(1)) {
+  | Some(a) => expect(a) |> toEqual(1)
+  | _ => expect(0) |> toEqual(1)
+  }
 );
 
-test(
-  "none",
-  () =>
-    switch (none(1)) {
-    | None => expect(true) |> toEqual(true)
-    | _ => expect(false) |> toEqual(true)
-    }
+test("none", () =>
+  switch (none(1)) {
+  | None => expect(true) |> toEqual(true)
+  | _ => expect(false) |> toEqual(true)
+  }
 );
 
-test("isNone", () => expect((isNone(None), isNone(Some(1)))) |> toEqual((true, false)));
-
-test("isSome", () => expect((isSome(Some(1)), isSome(None))) |> toEqual((true, false)));
-
-test(
-  "default",
-  () => expect((default(false, Some(true)), default(false, None))) |> toEqual((true, false))
+test("isNone", () =>
+  expect((isNone(None), isNone(Some(1)))) |> toEqual((true, false))
 );
 
-test(
-  "ofResult",
-  () =>
-    expect((ofResult(Belt.Result.Ok(true)), ofResult(Belt.Result.Error(false))))
-    |> toEqual((Some(true), None))
+test("isSome", () =>
+  expect((isSome(Some(1)), isSome(None))) |> toEqual((true, false))
+);
+
+test("default", () =>
+  expect((default(false, Some(true)), default(false, None)))
+  |> toEqual((true, false))
+);
+
+test("ofResult", () =>
+  expect((
+    ofResult(Belt.Result.Ok(true)),
+    ofResult(Belt.Result.Error(false)),
+  ))
+  |> toEqual((Some(true), None))
 );
 
 /* TODO: Figure out how to test throwing an exception */
-describe("toExn", () => test("Some", () => expect(toExn("blah", Some(true))) |> toEqual(true)));
-
-test(
-  "firstSome",
-  () =>
-    expect((firstSome(Some(0), Some(1)), firstSome(None, Some(1)))) |> toEqual((Some(0), Some(1)))
+describe("toExn", () =>
+  test("Some", () =>
+    expect(toExn("blah", Some(true))) |> toEqual(true)
+  )
 );
 
-describe(
-  "Monad",
-  () => {
-    test(
-      "left identity",
-      () => {
-        let f = (x) => Some(x + 1);
-        expect(return(0) >>= f) |> toEqual(f(0))
-      }
-    );
-    test("right identity", () => expect(Some(0) >>= return) |> toEqual(Some(0)));
-    test(
-      "associativity",
-      () => {
-        let f = (x) => Some(x + 1);
-        let g = (x) => Some(x + 3);
-        expect(Some(0) >>= f >>= g) |> toEqual(Some(0) >>= ((x) => f(x) >>= g))
-      }
-    )
-  }
+test("firstSome", () =>
+  expect((firstSome(Some(0), Some(1)), firstSome(None, Some(1))))
+  |> toEqual((Some(0), Some(1)))
 );
 
-describe(
-  "Functor",
-  () => {
-    test(
-      "identity",
-      () => expect(Some(0) <$> Function.identity) |> toEqual(Some(0) |> Function.identity)
-    );
-    test(
-      "composition",
-      () => {
-        open Function;
-        let f = (x) => x + 1;
-        let g = (x) => x + 3;
-        expect(Some(0) <$> (f <|| g)) |> toEqual(Some(0) <$> g <$> f)
-      }
-    )
-  }
-);
+describe("Monad", () => {
+  test("left identity", () => {
+    let f = x => Some(x + 1);
+    expect(return(0) >>= f) |> toEqual(f(0));
+  });
+  test("right identity", () =>
+    expect(Some(0) >>= return) |> toEqual(Some(0))
+  );
+  test("associativity", () => {
+    let f = x => Some(x + 1);
+    let g = x => Some(x + 3);
+    expect(Some(0) >>= f >>= g) |> toEqual(Some(0) >>= (x => f(x) >>= g));
+  });
+});
+
+describe("Functor", () => {
+  test("identity", () =>
+    expect(Some(0) <$> Function.identity)
+    |> toEqual(Some(0) |> Function.identity)
+  );
+  test("composition", () => {
+    open Function;
+    let f = x => x + 1;
+    let g = x => x + 3;
+    expect(Some(0) <$> (f <|| g)) |> toEqual(Some(0) <$> g <$> f);
+  });
+});

--- a/__tests__/RList_test.re
+++ b/__tests__/RList_test.re
@@ -128,12 +128,12 @@ describe("adjust", () => {
   );
 });
 
-describe("aperature", () => {
+describe("aperture", () => {
   test("zero", () =>
-    expect(aperature(0, [1, 2, 3, 4, 5])) |> toEqual([[], [], [], [], []])
+    expect(aperture(0, [1, 2, 3, 4, 5])) |> toEqual([[], [], [], [], []])
   );
   test("less than length", () =>
-    expect(aperature(2, [1, 2, 3, 4, 5]))
+    expect(aperture(2, [1, 2, 3, 4, 5]))
     |> toEqual([[1, 2], [2, 3], [3, 4], [4, 5]])
   );
   test("greater than length", () =>

--- a/__tests__/RList_test.re
+++ b/__tests__/RList_test.re
@@ -4,278 +4,320 @@ open Expect;
 
 open RList;
 
-test("head", () => expect((head([1]), head([]))) |> toEqual((Some(1), None)));
-
-test("tail", () => expect((tail([1, 2]), tail([]))) |> toEqual((Some([2]), None)));
-
-test("nth", () => expect((nth(0, [1]), nth(1, [1]))) |> toEqual((Some(1), None)));
-
-test("init", () => expect((init([1, 2]), init([]))) |> toEqual((Some([1]), None)));
-
-test("last", () => expect((last([1, 2]), init([]))) |> toEqual((Some(2), None)));
-
-test("append", () => expect(append(1, [])) |> toEqual([1]));
-
-test("concat", () => expect(concat([1], [0])) |> toEqual([0, 1]));
-
-describe(
-  "take",
-  () => {
-    test("too small", () => expect(take(3, [1, 2])) |> toEqual([1, 2]));
-    test("big enough", () => expect(take(3, [1, 2, 3, 4])) |> toEqual([1, 2, 3]))
-  }
+test("head", () =>
+  expect((head([1]), head([]))) |> toEqual((Some(1), None))
 );
 
-describe(
-  "takeLast",
-  () => {
-    test("too small", () => expect(takeLast(3, [1, 2])) |> toEqual([1, 2]));
-    test("big enough", () => expect(takeLast(3, [1, 2, 3, 4])) |> toEqual([2, 3, 4]))
-  }
+test("tail", () =>
+  expect((tail([1, 2]), tail([]))) |> toEqual((Some([2]), None))
 );
 
-test("takeWhile", () => expect(takeWhile((x) => x < 5, [1, 2, 3, 4, 5])) |> toEqual([1, 2, 3, 4]));
-
-test(
-  "takeLastWhile",
-  () => expect(takeLastWhile((x) => x > 1, [1, 2, 3, 4, 5])) |> toEqual([2, 3, 4, 5])
+test("nth", () =>
+  expect((nth(0, [1]), nth(1, [1]))) |> toEqual((Some(1), None))
 );
 
-describe(
-  "drop",
-  () => {
-    test("too small", () => expect(drop(3, [1, 2])) |> toEqual([]));
-    test("big enough", () => expect(drop(3, [1, 2, 3, 4])) |> toEqual([4]))
-  }
+test("init", () =>
+  expect((init([1, 2]), init([]))) |> toEqual((Some([1]), None))
 );
 
-describe(
-  "dropLast",
-  () => {
-    test("too small", () => expect(dropLast(3, [1, 2])) |> toEqual([]));
-    test("big enough", () => expect(dropLast(3, [1, 2, 3, 4])) |> toEqual([1]))
-  }
+test("last", () =>
+  expect((last([1, 2]), init([]))) |> toEqual((Some(2), None))
 );
 
-test("dropWhile", () => expect(dropWhile((x) => x < 5, [1, 2, 3, 4, 5])) |> toEqual([5]));
-
-test(
-  "dropLastWhile",
-  () => expect(dropLastWhile((x) => x > 2, [1, 2, 3, 4, 5])) |> toEqual([1, 2])
+test("append", () =>
+  expect(append(1, [])) |> toEqual([1])
 );
 
-test(
-  "dropRepeatsWith",
-  () =>
-    expect(dropRepeatsWith(Util.eqBy(abs), [1, (-1), 1, 3, 4, (-4), (-4), (-5), 5, 3, 3]))
-    |> toEqual([1, 3, 4, (-5), 3])
+test("concat", () =>
+  expect(concat([1], [0])) |> toEqual([0, 1])
 );
 
-test(
-  "dropRepeats",
-  () => expect(dropRepeats([1, 1, 1, 2, 3, 4, 4, 2, 2])) |> toEqual([1, 2, 3, 4, 2])
+describe("take", () => {
+  test("too small", () =>
+    expect(take(3, [1, 2])) |> toEqual([1, 2])
+  );
+  test("big enough", () =>
+    expect(take(3, [1, 2, 3, 4])) |> toEqual([1, 2, 3])
+  );
+});
+
+describe("takeLast", () => {
+  test("too small", () =>
+    expect(takeLast(3, [1, 2])) |> toEqual([1, 2])
+  );
+  test("big enough", () =>
+    expect(takeLast(3, [1, 2, 3, 4])) |> toEqual([2, 3, 4])
+  );
+});
+
+test("takeWhile", () =>
+  expect(takeWhile(x => x < 5, [1, 2, 3, 4, 5])) |> toEqual([1, 2, 3, 4])
 );
 
-describe(
-  "splitAt",
-  () => {
-    test("split at 0", () => expect(splitAt(0, [1, 2, 3])) |> toEqual(([], [1, 2, 3])));
-    test("split at 1", () => expect(splitAt(1, [1, 2, 3])) |> toEqual(([1], [2, 3])));
-    test("split at last", () => expect(splitAt(3, [1, 2, 3])) |> toEqual(([1, 2, 3], [])))
-  }
+test("takeLastWhile", () =>
+  expect(takeLastWhile(x => x > 1, [1, 2, 3, 4, 5]))
+  |> toEqual([2, 3, 4, 5])
 );
 
-describe(
-  "adjust",
-  () => {
-    let add10 = (x) => x + 10;
-    test("adjust first", () => expect(adjust(add10, 0, [1, 2, 3])) |> toEqual([11, 2, 3]));
-    test("adjust middle", () => expect(adjust(add10, 1, [1, 2, 3])) |> toEqual([1, 12, 3]));
-    test("adjust last", () => expect(adjust(add10, 2, [1, 2, 3])) |> toEqual([1, 2, 13]));
-    test("adjust past last", () => expect(adjust(add10, 3, [1, 2, 3])) |> toEqual([1, 2, 3]))
-  }
+describe("drop", () => {
+  test("too small", () =>
+    expect(drop(3, [1, 2])) |> toEqual([])
+  );
+  test("big enough", () =>
+    expect(drop(3, [1, 2, 3, 4])) |> toEqual([4])
+  );
+});
+
+describe("dropLast", () => {
+  test("too small", () =>
+    expect(dropLast(3, [1, 2])) |> toEqual([])
+  );
+  test("big enough", () =>
+    expect(dropLast(3, [1, 2, 3, 4])) |> toEqual([1])
+  );
+});
+
+test("dropWhile", () =>
+  expect(dropWhile(x => x < 5, [1, 2, 3, 4, 5])) |> toEqual([5])
 );
 
-describe(
-  "aperature",
-  () => {
-    test("zero", () => expect(aperature(0, [1, 2, 3, 4, 5])) |> toEqual([[], [], [], [], []]));
-    test(
-      "less than length",
-      () => expect(aperature(2, [1, 2, 3, 4, 5])) |> toEqual([[1, 2], [2, 3], [3, 4], [4, 5]])
-    );
-    test("greater than length", () => expect(aperature(7, [1, 2, 3, 4, 5])) |> toEqual([]))
-  }
+test("dropLastWhile", () =>
+  expect(dropLastWhile(x => x > 2, [1, 2, 3, 4, 5])) |> toEqual([1, 2])
 );
 
-test(
-  "containsWith",
-  () => {
-    let even = (x) => x mod 2 == 0;
-    expect((containsWith(even, [1, 2, 3]), containsWith(even, [1, 3, 5])))
-    |> toEqual((true, false))
-  }
+test("dropRepeatsWith", () =>
+  expect(
+    dropRepeatsWith(
+      Util.eqBy(abs),
+      [1, (-1), 1, 3, 4, (-4), (-4), (-5), 5, 3, 3],
+    ),
+  )
+  |> toEqual([1, 3, 4, (-5), 3])
 );
 
-test(
-  "contains",
-  () => expect((contains(2, [1, 2, 3]), contains(2, [1, 3, 5]))) |> toEqual((true, false))
+test("dropRepeats", () =>
+  expect(dropRepeats([1, 1, 1, 2, 3, 4, 4, 2, 2]))
+  |> toEqual([1, 2, 3, 4, 2])
 );
 
-test(
-  "endsWith",
-  () => expect((endsWith(3, [1, 2, 3]), endsWith(2, [1, 2, 3]))) |> toEqual((true, false))
+describe("splitAt", () => {
+  test("split at 0", () =>
+    expect(splitAt(0, [1, 2, 3])) |> toEqual(([], [1, 2, 3]))
+  );
+  test("split at 1", () =>
+    expect(splitAt(1, [1, 2, 3])) |> toEqual(([1], [2, 3]))
+  );
+  test("split at last", () =>
+    expect(splitAt(3, [1, 2, 3])) |> toEqual(([1, 2, 3], []))
+  );
+});
+
+describe("adjust", () => {
+  let add10 = x => x + 10;
+  test("adjust first", () =>
+    expect(adjust(add10, 0, [1, 2, 3])) |> toEqual([11, 2, 3])
+  );
+  test("adjust middle", () =>
+    expect(adjust(add10, 1, [1, 2, 3])) |> toEqual([1, 12, 3])
+  );
+  test("adjust last", () =>
+    expect(adjust(add10, 2, [1, 2, 3])) |> toEqual([1, 2, 13])
+  );
+  test("adjust past last", () =>
+    expect(adjust(add10, 3, [1, 2, 3])) |> toEqual([1, 2, 3])
+  );
+});
+
+describe("aperature", () => {
+  test("zero", () =>
+    expect(aperature(0, [1, 2, 3, 4, 5])) |> toEqual([[], [], [], [], []])
+  );
+  test("less than length", () =>
+    expect(aperature(2, [1, 2, 3, 4, 5]))
+    |> toEqual([[1, 2], [2, 3], [3, 4], [4, 5]])
+  );
+  test("greater than length", () =>
+    expect(aperture(7, [1, 2, 3, 4, 5])) |> toEqual([])
+  );
+});
+
+test("containsWith", () => {
+  let even = x => x mod 2 == 0;
+  expect((containsWith(even, [1, 2, 3]), containsWith(even, [1, 3, 5])))
+  |> toEqual((true, false));
+});
+
+test("contains", () =>
+  expect((contains(2, [1, 2, 3]), contains(2, [1, 3, 5])))
+  |> toEqual((true, false))
 );
 
-test(
-  "find",
-  () => expect((find(Util.eq(3), [1, 2, 3]), find(Util.eq(3), [1, 2]))) |> toEqual((Some(3), None))
+test("endsWith", () =>
+  expect((endsWith(3, [1, 2, 3]), endsWith(2, [1, 2, 3])))
+  |> toEqual((true, false))
 );
 
-test(
-  "findIndex",
-  () =>
-    expect((findIndex(Util.eq(3), [1, 2, 3, 3]), findIndex(Util.eq(3), [1, 2])))
-    |> toEqual((Some(2), None))
+test("find", () =>
+  expect((find(Util.eq(3), [1, 2, 3]), find(Util.eq(3), [1, 2])))
+  |> toEqual((Some(3), None))
 );
 
-test(
-  "findLastIndex",
-  () =>
-    expect((findLastIndex(Util.eq(3), [1, 2, 3, 3]), findLastIndex(Util.eq(3), [1, 2])))
-    |> toEqual((Some(3), None))
+test("findIndex", () =>
+  expect((
+    findIndex(Util.eq(3), [1, 2, 3, 3]),
+    findIndex(Util.eq(3), [1, 2]),
+  ))
+  |> toEqual((Some(2), None))
 );
 
-describe(
-  "groupWith",
-  () => {
-    test(
-      "equals",
-      () =>
-        expect(groupWith(Util.eq, [0, 1, 1, 2, 3, 5, 8, 13, 21]))
-        |> toEqual([[0], [1, 1], [2], [3], [5], [8], [13], [21]])
-    );
-    test(
-      "add",
-      () =>
-        expect(groupWith((a, b) => a + 1 == b, [0, 1, 1, 2, 3, 5, 8, 13, 21]))
-        |> toEqual([[0, 1], [1, 2, 3], [5], [8], [13], [21]])
-    );
-    test(
-      "div by 2",
-      () =>
-        expect(groupWith((a, b) => a mod 2 == b mod 2, [0, 1, 1, 2, 3, 5, 8, 13, 21]))
-        |> toEqual([[0], [1, 1], [2], [3, 5], [8], [13, 21]])
+test("findLastIndex", () =>
+  expect((
+    findLastIndex(Util.eq(3), [1, 2, 3, 3]),
+    findLastIndex(Util.eq(3), [1, 2]),
+  ))
+  |> toEqual((Some(3), None))
+);
+
+describe("groupWith", () => {
+  test("equals", () =>
+    expect(groupWith(Util.eq, [0, 1, 1, 2, 3, 5, 8, 13, 21]))
+    |> toEqual([[0], [1, 1], [2], [3], [5], [8], [13], [21]])
+  );
+  test("add", () =>
+    expect(groupWith((a, b) => a + 1 == b, [0, 1, 1, 2, 3, 5, 8, 13, 21]))
+    |> toEqual([[0, 1], [1, 2, 3], [5], [8], [13], [21]])
+  );
+  test("div by 2", () =>
+    expect(
+      groupWith(
+        (a, b) => a mod 2 == b mod 2,
+        [0, 1, 1, 2, 3, 5, 8, 13, 21],
+      ),
     )
-  }
+    |> toEqual([[0], [1, 1], [2], [3, 5], [8], [13, 21]])
+  );
+});
+
+test("indexOf", () =>
+  expect((indexOf(2, [1, 2, 3]), indexOf(5, [1, 2, 3])))
+  |> toEqual((Some(1), None))
 );
 
-test(
-  "indexOf",
-  () => expect((indexOf(2, [1, 2, 3]), indexOf(5, [1, 2, 3]))) |> toEqual((Some(1), None))
+test("lastIndexOf", () =>
+  expect((lastIndexOf(2, [1, 2, 2]), lastIndexOf(5, [1, 2, 2])))
+  |> toEqual((Some(2), None))
 );
 
-test(
-  "lastIndexOf",
-  () => expect((lastIndexOf(2, [1, 2, 2]), lastIndexOf(5, [1, 2, 2]))) |> toEqual((Some(2), None))
+test("insert", () =>
+  expect(insert(2, 5, [1, 2, 3])) |> toEqual([1, 2, 5, 3])
 );
 
-test("insert", () => expect(insert(2, 5, [1, 2, 3])) |> toEqual([1, 2, 5, 3]));
-
-test("insertAll", () => expect(insertAll(2, [5, 5], [1, 2, 3])) |> toEqual([1, 2, 5, 5, 3]));
-
-test(
-  "intersperse",
-  () => expect(intersperse("n", ["ba", "a", "a"])) |> toEqual(["ba", "n", "a", "n", "a"])
+test("insertAll", () =>
+  expect(insertAll(2, [5, 5], [1, 2, 3])) |> toEqual([1, 2, 5, 5, 3])
 );
 
-test("join", () => expect(join(":", ["1", "2", "3"])) |> toEqual("1:2:3"));
-
-test(
-  "none",
-  () => {
-    let even = (x) => x mod 2 == 0;
-    expect((none(even, [1, 3, 5]), none(even, [2, 4, 6]))) |> toEqual((true, false))
-  }
+test("intersperse", () =>
+  expect(intersperse("n", ["ba", "a", "a"]))
+  |> toEqual(["ba", "n", "a", "n", "a"])
 );
 
-test("rangeInt", () => expect(rangeInt(1, 0, 3)) |> toEqual([0, 1, 2, 3]));
-
-test(
-  "reduceWhile",
-  () => {
-    let isOdd = (_, x) => x mod 2 == 1;
-    let xs = [1, 3, 5, 60, 777, 800];
-    expect(reduceWhile(isOdd, (acc, x) => acc + x, 0, xs)) |> toEqual(9)
-  }
+test("join", () =>
+  expect(join(":", ["1", "2", "3"])) |> toEqual("1:2:3")
 );
 
-test(
-  "reject",
-  () => {
-    let isOdd = (x) => x mod 2 == 1;
-    expect(reject(isOdd, [1, 2, 3])) |> toEqual([2])
-  }
+test("none", () => {
+  let even = x => x mod 2 == 0;
+  expect((none(even, [1, 3, 5]), none(even, [2, 4, 6])))
+  |> toEqual((true, false));
+});
+
+test("rangeInt", () =>
+  expect(rangeInt(1, 0, 3)) |> toEqual([0, 1, 2, 3])
 );
 
-test("remove", () => expect(remove(1, 1, [1, 2, 3])) |> toEqual([1, 3]));
+test("reduceWhile", () => {
+  let isOdd = (_, x) => x mod 2 == 1;
+  let xs = [1, 3, 5, 60, 777, 800];
+  expect(reduceWhile(isOdd, (acc, x) => acc + x, 0, xs)) |> toEqual(9);
+});
 
-test("repeat", () => expect(repeat(1, 3)) |> toEqual([1, 1, 1]));
+test("reject", () => {
+  let isOdd = x => x mod 2 == 1;
+  expect(reject(isOdd, [1, 2, 3])) |> toEqual([2]);
+});
 
-test(
-  "scan",
-  () => {
-    let numbers = [1, 2, 3, 4];
-    let multiply = (x, y) => x * y;
-    expect(scan(multiply, 1, numbers)) |> toEqual([1, 1, 2, 6, 24])
-  }
+test("remove", () =>
+  expect(remove(1, 1, [1, 2, 3])) |> toEqual([1, 3])
 );
 
-test("slice", () => expect(slice(1, 3, [1, 2, 3, 4, 5])) |> toEqual([2, 3, 4]));
-
-test(
-  "splitEvery",
-  () => expect(splitEvery(2, [1, 2, 3, 4, 5, 6])) |> toEqual([[1, 2], [3, 4], [5, 6]])
+test("repeat", () =>
+  expect(repeat(1, 3)) |> toEqual([1, 1, 1])
 );
 
-test(
-  "splitWhen",
-  () => {
-    let even = (x) => x mod 2 == 0;
-    expect(splitWhen(even, [1, 2, 3])) |> toEqual(([1], [2, 3]))
-  }
+test("scan", () => {
+  let numbers = [1, 2, 3, 4];
+  let multiply = (x, y) => x * y;
+  expect(scan(multiply, 1, numbers)) |> toEqual([1, 1, 2, 6, 24]);
+});
+
+test("slice", () =>
+  expect(slice(1, 3, [1, 2, 3, 4, 5])) |> toEqual([2, 3, 4])
 );
 
-test(
-  "startsWith",
-  () => expect((startsWith(1, [1, 2, 3]), startsWith(2, [1, 2, 3]))) |> toEqual((true, false))
+test("splitEvery", () =>
+  expect(splitEvery(2, [1, 2, 3, 4, 5, 6]))
+  |> toEqual([[1, 2], [3, 4], [5, 6]])
 );
 
-test("times", () => expect(times(Function.identity, 5)) |> toEqual([0, 1, 2, 3, 4]));
+test("splitWhen", () => {
+  let even = x => x mod 2 == 0;
+  expect(splitWhen(even, [1, 2, 3])) |> toEqual(([1], [2, 3]));
+});
 
-test(
-  "uniqBy",
-  () => expect(uniqBy(abs, [(-1), (-5), 2, 10, 1, 2])) |> toEqual([(-1), (-5), 2, 10])
+test("startsWith", () =>
+  expect((startsWith(1, [1, 2, 3]), startsWith(2, [1, 2, 3])))
+  |> toEqual((true, false))
 );
 
-test("uniq", () => expect(uniq([1, 1, 2, 3, 2, 1, 3])) |> toEqual([1, 2, 3]));
-
-test("union", () => expect(union([1, 2, 3], [2, 3, 4])) |> toEqual([1, 2, 3, 4]));
-
-test("update", () => expect(update(5, 1, [1, 2, 3])) |> toEqual([1, 5, 3]));
-
-test("without", () => expect(without([2, 4], [1, 2, 3, 4, 5])) |> toEqual([1, 3, 5]));
-
-test(
-  "zipWith",
-  () => {
-    let multiply = (a, b) => a * b;
-    expect(zipWith(multiply, [1, 2, 3], [4, 5, 6])) |> toEqual([4, 10, 18])
-  }
+test("times", () =>
+  expect(times(Function.identity, 5)) |> toEqual([0, 1, 2, 3, 4])
 );
 
-test("difference", () => expect(difference([1, 2, 3], [3, 4, 5])) |> toEqual([1, 2, 4, 5]));
+test("uniqBy", () =>
+  expect(uniqBy(abs, [(-1), (-5), 2, 10, 1, 2]))
+  |> toEqual([(-1), (-5), 2, 10])
+);
 
-test("intersection", () => expect(intersection([1, 2, 3], [3, 4, 5])) |> toEqual([3]));
+test("uniq", () =>
+  expect(uniq([1, 1, 2, 3, 2, 1, 3])) |> toEqual([1, 2, 3])
+);
 
-test("zip", () => expect(zip([1, 2, 3], [4, 5, 6])) |> toEqual([(1, 4), (2, 5), (3, 6)]));
+test("union", () =>
+  expect(union([1, 2, 3], [2, 3, 4])) |> toEqual([1, 2, 3, 4])
+);
+
+test("update", () =>
+  expect(update(5, 1, [1, 2, 3])) |> toEqual([1, 5, 3])
+);
+
+test("without", () =>
+  expect(without([2, 4], [1, 2, 3, 4, 5])) |> toEqual([1, 3, 5])
+);
+
+test("zipWith", () => {
+  let multiply = (a, b) => a * b;
+  expect(zipWith(multiply, [1, 2, 3], [4, 5, 6])) |> toEqual([4, 10, 18]);
+});
+
+test("difference", () =>
+  expect(difference([1, 2, 3], [3, 4, 5])) |> toEqual([1, 2, 4, 5])
+);
+
+test("intersection", () =>
+  expect(intersection([1, 2, 3], [3, 4, 5])) |> toEqual([3])
+);
+
+test("zip", () =>
+  expect(zip([1, 2, 3], [4, 5, 6]))
+  |> toEqual([(1, 4), (2, 5), (3, 6)])
+);

--- a/src/RList.re
+++ b/src/RList.re
@@ -104,7 +104,7 @@ let adjust = (f, i, xs) => {
   };
 };
 
-let aperature = {
+let aperture = {
   let rec loop = (i, xs, acc) =>
     switch (xs) {
     | [] => acc

--- a/src/RList.rei
+++ b/src/RList.rei
@@ -53,7 +53,7 @@ let splitAt: (int, list('a)) => (list('a), list('a));
 
 let adjust: ('a => 'a, int, list('a)) => list('a);
 
-let aperature: (int, list('a)) => list(list('a));
+let aperture: (int, list('a)) => list(list('a));
 
 let containsWith: ('a => bool, list('a)) => bool;
 


### PR DESCRIPTION
`aperature` had a typo in its name. Also while doing https://github.com/jonlaing/rationale/pull/11, I forgot to refmt the tests.