### PR TITLE
Add writer ADT

### DIFF
--- a/__tests__/Monoid_test.re
+++ b/__tests__/Monoid_test.re
@@ -39,5 +39,3 @@ describe("Monoid", () => {
     expect(M_String.concat(["a", "b", "c"])) |> toEqual("abc")
   );
 });
-
-

--- a/__tests__/Monoid_test.re
+++ b/__tests__/Monoid_test.re
@@ -1,0 +1,43 @@
+open Jest;
+
+open Expect;
+
+open! Monoid;
+
+describe("Monoid", () => {
+  module M_String = Monoid.MakeGeneral({
+      type t = string;
+      let empty = "";
+      let append = (a, b) => a ++ b;
+      let rec concat = xs => switch xs {
+      | [] => ""
+      | [a, ...rs] => append(a, concat(rs))
+      };
+  });
+
+  test("Associativity", () => 
+    expect(
+      M_String.concat(["a", M_String.concat(["b", "c"])])
+    ) |> toEqual(
+      M_String.concat([M_String.concat(["a", "b"]), "c"])
+    )
+  );
+
+  test("Right identity", () => 
+    expect(M_String.concat(["a", M_String.empty])) |> toEqual("a")
+  );
+
+  test("Left identity", () => 
+    expect(M_String.concat([M_String.empty, "a"])) |> toEqual("a")
+  );
+  
+  test("append", () => 
+    expect(M_String.append("a", "b")) |> toEqual("ab")
+  );
+
+  test("concat", () => 
+    expect(M_String.concat(["a", "b", "c"])) |> toEqual("abc")
+  );
+});
+
+

--- a/__tests__/Writer_test.re
+++ b/__tests__/Writer_test.re
@@ -11,6 +11,41 @@ module WriterList = Writer.MakeWriter({
   let concat = xs => List.concat(xs);
 });
 
+describe("Applicative", () => {
+  open! Writer.WriterString;
+  open! Function;
+  test("composition", () => {
+    let f = Writer({ runWriter: (a => a + a, "") })
+    let g = Writer({ runWriter: (a => a * a, "") })
+    let v = Writer({ runWriter: (1, "") })
+     
+    expect(
+      pure (compose) <*> f <*> g <*> v
+    ) |> toEqual(
+      f <*> (g <*> v)
+    )
+  });
+  test("identity", () => {
+    let v = Writer({ runWriter: (1, "") })
+
+    expect(
+      pure (identity) <*> v
+    ) |> toEqual(
+      v
+    )
+  });
+  test("homomorphism", () => {
+    let f = a => a + a;
+    let x = 1;
+
+    expect(
+      pure (f) <*> pure (x)
+    ) |> toEqual(
+      pure (f(x))
+    )
+  });
+});
+
 describe("Monad", () => {
   test("left identity", () => {
     open! Writer.WriterString;

--- a/__tests__/Writer_test.re
+++ b/__tests__/Writer_test.re
@@ -1,0 +1,39 @@
+open Jest;
+
+open Expect;
+
+open! Writer;
+
+module WriterList = Writer.MakeWriter({
+  type t = list(int);
+  let empty = [];
+  let append = (a, b) => List.append(a, b);
+  let concat = xs => List.concat(xs);
+});
+
+describe("Monad", () => {
+  test("left identity", () => {
+    open! Writer.WriterString;
+    let add10 = x => Writer({ runWriter: (x + 10, "add10")});
+    expect(
+      return(5) >>= add10
+    ) |> toEqual(add10(5));
+  });
+
+  test("right identity", () => {
+    open! Writer.WriterSum;
+    let init42 = Writer({ runWriter: ("Meaning of life", 42)});
+    expect(
+      init42 >>= return
+    ) |> toEqual(init42)
+  });
+
+  test("associativity", () => {
+    open! WriterList;
+    let init = Writer({ runWriter: (10, [])});
+    let f = x => Writer({ runWriter: (x * 100, [1])});
+    let g = x => Writer({ runWriter: (x * 200, [2])});
+
+    expect(init >>= f >>= g) |> toEqual(init >>= (x => f(x) >>= g));
+  });
+});

--- a/src/Monoid.re
+++ b/src/Monoid.re
@@ -1,0 +1,14 @@
+module type General = {
+  type t;
+  let empty: t;
+  let append: (t, t) => t;
+  let concat: list(t) => t
+  
+
+};
+
+module MakeGeneral = (M: General) => {
+  let empty = M.empty;
+  let append = M.append;
+  let concat = M.concat;
+}

--- a/src/Monoid.re
+++ b/src/Monoid.re
@@ -3,8 +3,6 @@ module type General = {
   let empty: t;
   let append: (t, t) => t;
   let concat: list(t) => t
-  
-
 };
 
 module MakeGeneral = (M: General) => {

--- a/src/Writer.re
+++ b/src/Writer.re
@@ -3,10 +3,6 @@ type tx('a, 'w) = {
 }
 type writer('a, 'w) = Writer(tx('a, 'w));
 
-module type LogType = {
-  type t;
-}
-
 module MakeWriter = (M: Monoid.General) => {
   include (Monad.MakeBasic({
     type t('a) = writer('a, M.t);

--- a/src/Writer.re
+++ b/src/Writer.re
@@ -1,0 +1,48 @@
+type tx('a, 'w) = {
+  runWriter: ('a, 'w)
+}
+type writer('a, 'w) = Writer(tx('a, 'w));
+
+module type LogType = {
+  type t;
+}
+
+module MakeWriter = (M: Monoid.General) => {
+  include (Monad.MakeBasic({
+    type t('a) = writer('a, M.t);
+    let return = a => Writer({ runWriter: (a, M.empty)});
+    let bind = (Writer({ runWriter: (x, v)}), f) => {
+      let (Writer({ runWriter: (y, vp)})) = f(x);
+      Writer({ runWriter: (y, M.append(v, vp))})
+    }
+    let fmap = `DefineWithBind;
+  }));
+  include (Applicative.MakeBasic({
+    type t('a) = writer('a, M.t);
+    let pure = a => Writer({ runWriter: (a, M.empty)});
+    let apply = (Writer({ runWriter: (f, v)}), a) => {
+      let (Writer({ runWriter: (fp, vp)})) = bind(a, b => return(f(b)));
+      Writer({ runWriter: (fp, M.append(v, vp))});
+    };
+  }));
+}
+
+module WriterString = MakeWriter({
+  type t = string;
+  let empty = "";
+  let append = (a, b) => a ++ b;
+  let rec concat = xs => switch xs {
+    | [] => ""
+    | [a, ...rs] => append(a, concat(rs))
+  };
+});
+
+module WriterSum = MakeWriter({
+  type t = int;
+  let empty = 0;
+  let append = (a, b) => a + b;
+  let rec concat = xs => switch xs {
+    | [] => 0
+    | [a, ...rs] => append(a, concat(rs))
+  };
+})


### PR DESCRIPTION
The goal of this PR is to add Writer and by it the required Monoid data type.
I'm not sure is it the "most" Reason way to define a module constructor functor inside another one, so if anyone has a better suggestion I would love to hear it.

[+] Monad implementation
[+] Applicative implementation
[+] Tests for monad implementation
